### PR TITLE
chore(deps): bump win32yank to 0.1.1

### DIFF
--- a/win32yank.nix
+++ b/win32yank.nix
@@ -1,6 +1,6 @@
 {pkgs ? import <nixpkgs>}: let
   pname = "win32yank";
-  version = "0.0.4";
+  version = "0.1.1";
   bin = "win32yank.exe";
 in
   pkgs.stdenv.mkDerivation {
@@ -8,7 +8,7 @@ in
 
     src = pkgs.fetchzip {
       url = "https://github.com/equalsraf/win32yank/releases/download/v${version}/win32yank-x64.zip";
-      sha256 = "1jzb2zabx777dpjn8bh94biakzch2ybw9bxs0sbhf67i84xxqi2n";
+      sha256 = "sha256-4ivE1cYZhYs4ibx5oiYMOhbse9bdOomk7RjgdVl5lD0=";
       stripRoot = false;
     };
 


### PR DESCRIPTION
This commit bumps the pkg for win32yank to v0.1.1 and updates the hash.

resolve #9